### PR TITLE
Assert no globals in the run_simple() and run_simulation() functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RPiR
 Type: Package
 Title: Reproducible Programming in R
-Version: 0.65.0
+Version: 0.65.1
 Authors@R: c(person("Sonia", "Mitchell", email = "sonia.mitchell@glasgow.ac.uk",
                   role = c("cre", "aut"), comment = c(ORCID = "0000-0003-1536-2066")),
              person("Richard", "Reeve", email = "richard.reeve@glasgow.ac.uk",

--- a/R/assert_no_globals.R
+++ b/R/assert_no_globals.R
@@ -4,15 +4,17 @@
 #' This function will stop code execution with an error if the function
 #' passed in has a global variable
 #'
-#' @param fname function name to check for global
+#' @param test_function function to check for global variables
+#' @param name optionally (otherwise taken from test_function) name of function
 #'
 #' @return nothing
 #' @export
 #'
-assert_no_globals <- function(fname) {
-  globals <- codetools::findGlobals(fname, merge = FALSE)$variables
+assert_no_globals <- function(test_function,
+                              name = deparse1(substitute(test_function))) {
+  globals <- codetools::findGlobals(test_function, merge = FALSE)$variables
   if (length(globals) != 0) {
-    stop(paste0("Function ", deparse1(substitute(fname)),
+    stop(paste0("Function ", name,
                 "() may not use global variable(s): ", globals))
   }
   NULL

--- a/R/run_simple.R
+++ b/R/run_simple.R
@@ -2,13 +2,21 @@
 #'
 #' @description
 #' A generic function to run a simulation loop for a fixed period of time.
+#' \code{run_simple()} will call \code{step_function(initial.pop, ...)} over
+#' and over until the time ends or \code{step_function()} reports that the
+#' experiment has ended.
+#'
+#' @seealso [run_simulation()] if you want a more flexible version of this
+#' function that will allow your \code{step_function()} to return just a
+#' data frame and will print some debugging information on request.
 #'
 #' @param step_function Function to run a timestep (\code{step_function()})
 #'   which returns a list containing elements \code{updated.pop} with the
 #'   updated population and \code{end.experiment} which is TRUE if the
 #'   experiment has ended (FALSE if not)
 #' @param initial.pop Initial population data frame with columns corresponding
-#'   to function requirements
+#'   to function requirements. This *must* include a \code{time} column so that
+#'   \code{run_simple()} can check whether the \code{end.time} has been reached.
 #' @param end.time End time of simulation
 #' @param ... (optionally) any other arguments for \code{step_function()},
 #'   e.g. parameters or timestep

--- a/R/run_simple.R
+++ b/R/run_simple.R
@@ -42,7 +42,8 @@
 #'
 run_simple <- function(step_function, initial.pop, end.time, ...) {
   # Check whether step_function uses global variables
-  RPiR::assert_no_globals(step_function)
+  RPiR::assert_no_globals(step_function,
+                          name = deparse1(substitute(step_function)))
 
   population.df <- latest.df <- initial.pop
   keep.going <- (latest.df$time < end.time)

--- a/R/run_simple.R
+++ b/R/run_simple.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' A generic function to run a simulation loop for a fixed period of time.
-
+#'
 #' @param step_function Function to run a timestep (\code{step_function()})
 #'   which returns a list containing elements \code{updated.pop} with the
 #'   updated population and \code{end.experiment} which is TRUE if the
@@ -34,12 +34,7 @@
 #'
 run_simple <- function(step_function, initial.pop, end.time, ...) {
   # Check whether step_function uses global variables
-  if (length(codetools::findGlobals(step_function,
-                                    merge = FALSE)$variables) > 0)
-    warning(paste("Function provided uses global variable(s):",
-                  paste(codetools::findGlobals(step_function,
-                                               merge = FALSE)$variables,
-                        collapse = ", ")))
+  RPiR::assert_no_globals(step_function)
 
   population.df <- latest.df <- initial.pop
   keep.going <- (latest.df$time < end.time)

--- a/R/run_simple.R
+++ b/R/run_simple.R
@@ -6,8 +6,8 @@
 #' and over until the time ends or \code{step_function()} reports that the
 #' experiment has ended.
 #'
-#' @seealso [run_simulation()] if you want a more flexible version of this
-#' function that will allow your \code{step_function()} to return just a
+#' @seealso \code{\link{run_simulation}} if you want a more flexible version
+#' of this function that will allow your \code{step_function()} to return just a
 #' data frame and will print some debugging information on request.
 #'
 #' @param step_function Function to run a timestep (\code{step_function()})

--- a/R/run_simulation.R
+++ b/R/run_simulation.R
@@ -63,9 +63,9 @@ run_simulation <- function(step_function, initial.pop, end.time,
     if (is.data.frame(data)) {
       # We have an experiment that doesn't end, or can't determine when it does
       latest.df <- data
+      ended <- FALSE
       cat("step_function() returns a data frame.\n")
-    }
-    else {
+    } else {
       # If a list, we have an experiment that can determine when it ends
       cat("step_function() returns a list.\n")
       list.names <- c("updated.pop", "end.experiment")

--- a/R/run_simulation.R
+++ b/R/run_simulation.R
@@ -49,7 +49,8 @@
 run_simulation <- function(step_function, initial.pop, end.time,
                            debug=FALSE, ...) {
   # Check whether step_function uses global variables
-  RPiR::assert_no_globals(step_function)
+  RPiR::assert_no_globals(step_function,
+                          name = deparse1(substitute(step_function)))
 
   # Collect and report debugging information to identify sources of errors
   pop.names <- colnames(initial.pop)

--- a/R/run_simulation.R
+++ b/R/run_simulation.R
@@ -9,13 +9,18 @@
 #' (potentially) useful debugging information while it runs. It will also
 #' check whether your function has any global variables.
 #'
+#' @seealso [run_simple()] if you want a much simpler and more restrictive
+#' version of the simulation code that may be useful for better understanding
+#' how the function works.
+#'
 #' @param step_function Function to run a timestep (\code{step_function()})
 #'   which returns a list containing elements \code{updated.pop} with the
 #'   updated population and \code{end.experiment} which is TRUE if the
 #'   experiment has ended (FALSE if not), OR which just returns a data frame
 #'   with the updated population
 #' @param initial.pop Initial population data frame with columns corresponding
-#'   to function requirements
+#'   to function requirements. This *must* include a \code{time} column so that
+#'   \code{run_simple()} can check whether the \code{end.time} has been reached.
 #' @param end.time End time of simulation
 #' @param debug (optionally) do you want to print out a limited amount of
 #'   debugging information about your code? - default FALSE

--- a/R/run_simulation.R
+++ b/R/run_simulation.R
@@ -2,7 +2,13 @@
 #'
 #' @description
 #' A generic function to run a simulation loop for a fixed period of time.
-
+#' This function can cope with model step functions that return an updated
+#' data frame, or functions that return a list with an \code{end.experiment}
+#' element and an \code{updated.pop} element. If the simulation isn't working
+#' you can set \code{debug = TRUE} in the arguments, and it will print some
+#' (potentially) useful debugging information while it runs. It will also
+#' check whether your function has any global variables.
+#'
 #' @param step_function Function to run a timestep (\code{step_function()})
 #'   which returns a list containing elements \code{updated.pop} with the
 #'   updated population and \code{end.experiment} which is TRUE if the
@@ -38,11 +44,7 @@
 run_simulation <- function(step_function, initial.pop, end.time,
                            debug=FALSE, ...) {
   # Check whether step_function uses global variables
-  if (length(codetools::findGlobals(step_function, merge = FALSE)$variables) > 0)
-    warning(paste("Function provided uses global variable(s):",
-                  paste(codetools::findGlobals(step_function,
-                                               merge = FALSE)$variables,
-                        collapse = ", ")))
+  RPiR::assert_no_globals(step_function)
 
   # Collect and report debugging information to identify sources of errors
   pop.names <- colnames(initial.pop)

--- a/R/run_simulation.R
+++ b/R/run_simulation.R
@@ -9,9 +9,9 @@
 #' (potentially) useful debugging information while it runs. It will also
 #' check whether your function has any global variables.
 #'
-#' @seealso [run_simple()] if you want a much simpler and more restrictive
-#' version of the simulation code that may be useful for better understanding
-#' how the function works.
+#' @seealso \code{\link{run_simple}} if you want a much simpler but more
+#' restrictive version of the simulation code that may be useful for better
+#' understanding how the function works.
 #'
 #' @param step_function Function to run a timestep (\code{step_function()})
 #'   which returns a list containing elements \code{updated.pop} with the

--- a/man/assert_no_globals.Rd
+++ b/man/assert_no_globals.Rd
@@ -4,10 +4,12 @@
 \alias{assert_no_globals}
 \title{assert_no_globals}
 \usage{
-assert_no_globals(fname)
+assert_no_globals(test_function, name = deparse1(substitute(test_function)))
 }
 \arguments{
-\item{fname}{function name to check for global}
+\item{test_function}{function to check for global variables}
+
+\item{name}{optionally (otherwise taken from test_function) name of function}
 }
 \value{
 nothing

--- a/man/run_simple.Rd
+++ b/man/run_simple.Rd
@@ -13,7 +13,8 @@ updated population and \code{end.experiment} which is TRUE if the
 experiment has ended (FALSE if not)}
 
 \item{initial.pop}{Initial population data frame with columns corresponding
-to function requirements}
+to function requirements. This *must* include a \code{time} column so that
+\code{run_simple()} can check whether the \code{end.time} has been reached.}
 
 \item{end.time}{End time of simulation}
 
@@ -25,6 +26,9 @@ Data frame containing population history of simulation over time
 }
 \description{
 A generic function to run a simulation loop for a fixed period of time.
+\code{run_simple()} will call \code{step_function(initial.pop, ...)} over
+and over until the time ends or \code{step_function()} reports that the
+experiment has ended.
 }
 \examples{
 
@@ -41,4 +45,9 @@ df <- data.frame(time=0, count=1)
 results <- run_simple(growth, df, 100, growth.rate=0.1)
 plot_populations(results)
 
+}
+\seealso{
+[run_simulation()] if you want a more flexible version of this
+function that will allow your \code{step_function()} to return just a
+data frame and will print some debugging information on request.
 }

--- a/man/run_simple.Rd
+++ b/man/run_simple.Rd
@@ -47,7 +47,7 @@ plot_populations(results)
 
 }
 \seealso{
-[run_simulation()] if you want a more flexible version of this
-function that will allow your \code{step_function()} to return just a
+\code{\link{run_simulation}} if you want a more flexible version
+of this function that will allow your \code{step_function()} to return just a
 data frame and will print some debugging information on request.
 }

--- a/man/run_simulation.Rd
+++ b/man/run_simulation.Rd
@@ -14,7 +14,8 @@ experiment has ended (FALSE if not), OR which just returns a data frame
 with the updated population}
 
 \item{initial.pop}{Initial population data frame with columns corresponding
-to function requirements}
+to function requirements. This *must* include a \code{time} column so that
+\code{run_simple()} can check whether the \code{end.time} has been reached.}
 
 \item{end.time}{End time of simulation}
 
@@ -51,4 +52,9 @@ df <- data.frame(time=0, count=1)
 results <- run_simulation(growth, df, 100, growth.rate=0.1, debug=TRUE)
 plot_populations(results)
 
+}
+\seealso{
+[run_simple()] if you want a much simpler and more restrictive
+version of the simulation code that may be useful for better understanding
+how the function works.
 }

--- a/man/run_simulation.Rd
+++ b/man/run_simulation.Rd
@@ -29,6 +29,12 @@ Data frame containing population history of simulation over time
 }
 \description{
 A generic function to run a simulation loop for a fixed period of time.
+This function can cope with model step functions that return an updated
+data frame, or functions that return a list with an \code{end.experiment}
+element and an \code{updated.pop} element. If the simulation isn't working
+you can set \code{debug = TRUE} in the arguments, and it will print some
+(potentially) useful debugging information while it runs. It will also
+check whether your function has any global variables.
 }
 \examples{
 

--- a/man/run_simulation.Rd
+++ b/man/run_simulation.Rd
@@ -54,7 +54,7 @@ plot_populations(results)
 
 }
 \seealso{
-[run_simple()] if you want a much simpler and more restrictive
-version of the simulation code that may be useful for better understanding
-how the function works.
+\code{\link{run_simple}} if you want a much simpler but more
+restrictive version of the simulation code that may be useful for better
+understanding how the function works.
 }


### PR DESCRIPTION
- [x] Fix `run_simple()` and `run_simulation()` to use new `assert_no_globals()` function. Closes #254 
- [x] Fix bug in `run_simulation()`. Closes #253 
- [x] Improve documentation of `run_simple()`. Closes #243 
- [x] Improve documentation of `run_simulation()` too
